### PR TITLE
Add GitHub workflows for ruff, pytest, and pre-commit

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,0 +1,28 @@
+name: Pytest
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.12
+
+      - name: Install dependencies
+        run: pip install .[dev]
+
+      - name: Run Pytest
+        run: pytest --maxfail=5 --disable-warnings --cov=src --cov-report=xml --cov-report=term-missing --tb=short -q

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -1,0 +1,28 @@
+name: Ruff Linting
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.12
+
+      - name: Install dependencies
+        run: pip install .[dev]
+
+      - name: Run Ruff
+        run: ruff .

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,10 @@
+repos:
+  - repo: https://github.com/pre-commit/mirrors-ruff
+    rev: v0.0.1
+    hooks:
+      - id: ruff
+
+  - repo: https://github.com/psf/black
+    rev: 21.9b0
+    hooks:
+      - id: black

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,4 +9,7 @@ dependencies = [
     "feedparser>=6.0.11",
     "listparser>=0.20",
     "rich>=13.9.4",
+    "ruff>=0.0.1",
+    "pytest>=6.2.5",
+    "pre-commit>=2.15.0",
 ]


### PR DESCRIPTION
Add GitHub workflows for ruff and pytest, and a pre-commit configuration for linting and formatting.

* Add `ruff.yml` in `.github/workflows` to run ruff for linting on push and pull request events.
* Add `pytest.yml` in `.github/workflows` to run pytest for testing on push and pull request events with specific options.
* Add `pre-commit-config.yaml` to configure pre-commit hooks for ruff and black.
* Modify `pyproject.toml` to include ruff, pytest, and pre-commit as dependencies.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/harperreed/ohpeehmel/pull/12?shareId=f19be3b8-d022-4f95-b3df-c1c34c086c88).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced automated testing and linting workflows using GitHub Actions for improved code quality.
	- Added pre-commit hooks for automated linting and formatting with Ruff and Black.

- **Dependencies**
	- Added new dependencies: Ruff, Pytest, and Pre-commit to enhance testing and code quality processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->